### PR TITLE
print out topic number when a msg is received by reactor node

### DIFF
--- a/reference_system_autoware/include/reference_system_autoware/node/command.hpp
+++ b/reference_system_autoware/include/reference_system_autoware/node/command.hpp
@@ -53,11 +53,11 @@ private:
     const int64_t accumulated_latency_in_ns =
       input_accumulated_latency + timestamp_in_ns - input_timestamp;
 
-    std::cout << "\nreceived message stats:\n";
-    std::cout << "  current timestamp in ns: " << timestamp_in_ns << std::endl;
-    std::cout << "  message timestamp in ns: " << input_timestamp << std::endl;
-    std::cout << "  accumulated latency in ns: " << accumulated_latency_in_ns <<
-      std::endl;
+//    std::cout << "\nreceived message stats:\n";
+//    std::cout << "  current timestamp in ns: " << timestamp_in_ns << std::endl;
+//    std::cout << "  message timestamp in ns: " << input_timestamp << std::endl;
+//    std::cout << "  accumulated latency in ns: " << accumulated_latency_in_ns <<
+//      std::endl;
   }
 
 private:

--- a/reference_system_autoware/include/reference_system_autoware/node/command.hpp
+++ b/reference_system_autoware/include/reference_system_autoware/node/command.hpp
@@ -52,12 +52,12 @@ private:
 
     const int64_t accumulated_latency_in_ns =
       input_accumulated_latency + timestamp_in_ns - input_timestamp;
-
-//    std::cout << "\nreceived message stats:\n";
-//    std::cout << "  current timestamp in ns: " << timestamp_in_ns << std::endl;
-//    std::cout << "  message timestamp in ns: " << input_timestamp << std::endl;
-//    std::cout << "  accumulated latency in ns: " << accumulated_latency_in_ns <<
-//      std::endl;
+    
+    RCLCPP_WARN_STREAM(this->get_logger(), std::endl <<
+      "  Received message statistics:" << std::endl <<
+      "    current timestamp in ns:   " << timestamp_in_ns << std::endl << 
+      "    message timestamp in ns:   " << input_timestamp << std::endl <<
+      "    accumulated latency in ns: " << accumulated_latency_in_ns << std::endl);
   }
 
 private:

--- a/reference_system_autoware/include/reference_system_autoware/node/command.hpp
+++ b/reference_system_autoware/include/reference_system_autoware/node/command.hpp
@@ -53,11 +53,10 @@ private:
     const int64_t accumulated_latency_in_ns =
       input_accumulated_latency + timestamp_in_ns - input_timestamp;
     
-    RCLCPP_WARN_STREAM(this->get_logger(), std::endl <<
-      "  Received message statistics:" << std::endl <<
-      "    current timestamp in ns:   " << timestamp_in_ns << std::endl << 
-      "    message timestamp in ns:   " << input_timestamp << std::endl <<
-      "    accumulated latency in ns: " << accumulated_latency_in_ns << std::endl);
+    RCLCPP_WARN_STREAM(this->get_logger(), "Received message statistics:");
+    RCLCPP_WARN_STREAM(this->get_logger(), "  current timestamp in ns:   " << timestamp_in_ns);
+    RCLCPP_WARN_STREAM(this->get_logger(), "  message timestamp in ns:   " << input_timestamp);
+    RCLCPP_WARN_STREAM(this->get_logger(), "  accumulated latency in ns: " << accumulated_latency_in_ns);
   }
 
 private:

--- a/reference_system_autoware/include/reference_system_autoware/node/reactor.hpp
+++ b/reference_system_autoware/include/reference_system_autoware/node/reactor.hpp
@@ -67,6 +67,9 @@ class Reactor : public rclcpp::Node {
     output_message.get().data[1] = timestamp_in_ns;
     output_message.get().data[2] = input_number;
     output_message.get().data[3] = number_cruncher_result.empty();
+
+    RCLCPP_INFO_STREAM(this->get_logger(), "Reacting to input[" << input_number << "]");
+
     publisher_->publish(std::move(output_message));
   }
 


### PR DESCRIPTION
Signed-off-by: Evan Flynn <evan.flynn@apex.ai>

per discussion with @elfenpiff.

adds a print to each time the reactor node receives a msg and prints which topic number (input number) it came from.

commented out the other prints so I could more easily see these ones. just let me know if you'd like me uncomment them again or even switch them over to `RCLCPP_INFO` type prints.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/apexai/reference-system-autoware/3)
<!-- Reviewable:end -->
